### PR TITLE
Fix API key validation: sanitize invisible chars, improve error messages

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -48,9 +48,14 @@ toggleEnabled.addEventListener('change', () => {
   });
 });
 
+/** Strip invisible / control characters the same way background.js does */
+function sanitizeKey(raw) {
+  return raw.replace(/[\u0000-\u001F\u007F-\u00A0\u200B-\u200D\uFEFF]/g, '').trim();
+}
+
 // Save all settings
 btnSave.addEventListener('click', async () => {
-  const apiKey = apiKeyInput.value.trim();
+  const apiKey = sanitizeKey(apiKeyInput.value);
   const model = modelSelect.value;
 
   if (!apiKey) {
@@ -59,8 +64,9 @@ btnSave.addEventListener('click', async () => {
     return;
   }
 
-  if (!apiKey.startsWith('sk-ant-')) {
-    showBanner('⚠ API key should start with sk-ant-', 'error');
+  // Soft format hint only — don't block if format looks unusual
+  if (apiKey.length < 20) {
+    showBanner('⚠ API key looks too short — please double-check it', 'error');
     return;
   }
 


### PR DESCRIPTION
- Strip zero-width, control, and non-printable unicode chars from key before sending (trim() alone doesn't catch these)
- Remove rigid sk-ant- prefix check that could block valid keys
- Return actual Anthropic API error message verbatim (was returning a generic 'Invalid API key' which hid the real cause)
- Catch network errors separately so fetch failures show clearly
- Apply same sanitizeKey() in checkGrammar path so stored keys are always clean at use time

https://claude.ai/code/session_01NUfUHf4adXFaoG1Mt3cQyh